### PR TITLE
Remove PKNCA dependency and provide AIC.list() replacement

### DIFF
--- a/respirometry_devel/DESCRIPTION
+++ b/respirometry_devel/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: respirometry
 Type: Package
 Title: Tools for Conducting and Analyzing Respirometry Experiments
-Version: x.y.z
-Date: yyyy-mm-dd
+Version: 1.4.0.9000
+Date: 2024-01-22
 Author: Matthew A. Birk
 Maintainer: Matthew A. Birk <matthewabirk@gmail.com>
 Description: Provides tools to enable the researcher to more precisely conduct
@@ -23,8 +23,6 @@ Imports:
     segmented (>= 1.0-0),
     stats,
     utils
-Depends:
-    PKNCA
 License: GPL-3
 LazyData: TRUE
 Encoding: UTF-8

--- a/respirometry_devel/R/calc_pcrit.R
+++ b/respirometry_devel/R/calc_pcrit.R
@@ -78,7 +78,8 @@ pcrit_internal = function(po2, mo2, avg_top_n = 1, level = 0.95, iqr = 1.5, NLR_
 	
 	mods = list(MM_mod, powr_mod, hyperbola_mod, pareto_mod, weibull_mod)
 	mod_names = c('MM_mod' = 'Michaelis-Menten', 'powr_mod' = 'Power', 'hyperbola_mod' = 'Hyperbola', 'pareto_mod' = 'Pareto', 'weibull_mod' = 'Weibull with intercept')
-	best_mod = mod_names[which.min(AIC(mods)$AIC)]
+	aic_vec <- sapply(mods, FUN = AIC)
+	best_mod = mod_names[which.min(aic_vec)]
 
 	
 	nlr_pcrits = list('Michaelis-Menten' = MM_pcrit, 'Power' = powr_pcrit, 'Hyperbola' = hyperbola_pcrit, 'Pareto' = pareto_pcrit, 'Weibull with intercept' = weibull_pcrit)


### PR DESCRIPTION
PKNCA is no longer exporting `AIC.list()`.  I intend to release a new version of PKNCA as soon as is reasonable (within 2 weeks is the goal).

The `AIC.list()` function is not core to PKNCA and has been slated for removal for a while (billdenney/pknca#71).  The next version which is intended for release soon will no longer export the function.  This PR removes the need for PKNCA and enables the functionality previously provided by the `AIC.list()` function in PKNCA.

Changes to DESCRIPTION date and version are to allow `devtools` to load the package.